### PR TITLE
Change lambda helper to default to arm

### DIFF
--- a/backend/lib/helpers/createNodeJsFunction.ts
+++ b/backend/lib/helpers/createNodeJsFunction.ts
@@ -1,11 +1,13 @@
 import { Stack } from "aws-cdk-lib";
-import { Runtime } from "aws-cdk-lib/aws-lambda";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { RetentionDays } from "aws-cdk-lib/aws-logs";
 
 interface NodejsFunctionProps {
   entry: string
   handler?: string
   runtime?: Runtime
+  architecture?: Architecture
   environment?: Record<string, string>
   bundling?: Record<string, string[]>
 }
@@ -15,13 +17,15 @@ export const createNodeJsFunction = (
   id: string,
   props: NodejsFunctionProps
 ): NodejsFunction => {
-  const { entry, handler, runtime, environment, bundling } = props
+  const { entry, handler, runtime, architecture, environment, bundling } = props
 
   const lambda = new NodejsFunction(stack, id, {
     entry,
     handler: handler ?? 'handler',
     runtime: runtime ?? Runtime.NODEJS_18_X,
+    architecture: architecture ?? Architecture.ARM_64,
     environment,
+    logRetention: RetentionDays.ONE_DAY,
     bundling: {
       minify: true,
       ...bundling,

--- a/backend/lib/stacks/StatelessStack.ts
+++ b/backend/lib/stacks/StatelessStack.ts
@@ -4,6 +4,7 @@ import { PolicyStatement, Effect } from "aws-cdk-lib/aws-iam";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { Cors } from "aws-cdk-lib/aws-apigateway";
 import { createNodeJsFunction } from '../helpers/createNodeJsFunction';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
 
 export class StatelessStack extends NestedStack {
   
@@ -14,6 +15,7 @@ export class StatelessStack extends NestedStack {
       entry: "lib/lambdas/hello.ts",
     })
 
+    // bcrypt doen't work on ARM architecture, so we need to use X86_64
     const registerUserLambda = createNodeJsFunction(this, "registerUser", {
       entry: "lib/lambdas/registerUser.ts",
       environment: {
@@ -23,6 +25,7 @@ export class StatelessStack extends NestedStack {
           1
         ),
       },
+      architecture: Architecture.X86_64,
       bundling: {
         nodeModules: ["bcrypt"],
       },
@@ -31,6 +34,7 @@ export class StatelessStack extends NestedStack {
     // NOTE - In a real project, you would use a KMS key to encrypt the secret
     // and then use the key to decrypt it at runtime. This is just a demo and I
     // didn't want to pay $0.4 a month :D.
+    // bcrypt doen't work on ARM architecture, so we need to use X86_64
     const authUserLambda = createNodeJsFunction(this, "authUser", {
       entry: "lib/lambdas/authUser.ts",
       environment: {
@@ -40,6 +44,7 @@ export class StatelessStack extends NestedStack {
           1
         ),
       },
+      architecture: Architecture.X86_64,
       bundling: {
         nodeModules: ["bcrypt"],
       },


### PR DESCRIPTION
Change the default architecture to ARM over x86 as it is cheaper and in some cases faster.
NOTE - It appear bcrypt doesn't support ARM, I've left both the register and auth lambdas using x86